### PR TITLE
fix: sync marketplace.json version with package.json (1.2.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
     "email": "melvyn@aiblueprint.dev"
   },
   "description": "AIBlueprint Claude Code configuration marketplace with custom agents, commands, and workflows",
-  "version": "1.2.3",
+  "version": "1.4.14",
   "plugins": [
     {
       "name": "base",
       "source": "./claude-code-config",
       "description": "AIBlueprint base configuration with custom agents, slash commands, hooks, and productivity workflows for Claude Code",
-      "version": "1.2.3",
+      "version": "1.4.14",
       "author": {
         "name": "Melvyn",
         "url": "https://github.com/melvynx"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
     "email": "melvyn@aiblueprint.dev"
   },
   "description": "AIBlueprint Claude Code configuration marketplace with custom agents, commands, and workflows",
-  "version": "1.0.1",
+  "version": "1.2.3",
   "plugins": [
     {
       "name": "base",
       "source": "./claude-code-config",
       "description": "AIBlueprint base configuration with custom agents, slash commands, hooks, and productivity workflows for Claude Code",
-      "version": "1.0.1",
+      "version": "1.2.3",
       "author": {
         "name": "Melvyn",
         "url": "https://github.com/melvynx"


### PR DESCRIPTION
## Summary
- Updated marketplace.json versions from 1.0.1 to 1.4.14 to match package.json

## Problem
The marketplace displays version 1.0.1 while the actual package version is 1.4.14, making it confusing to know if the plugin is up to date.

## Changes
- `.claude-plugin/marketplace.json` line 8: `"version": "1.0.1"` → `"version": "1.4.14"`
- `.claude-plugin/marketplace.json` line 14: `"version": "1.0.1"` → `"version": "1.4.14"`

## Note importante
⚠️ **Pour les futures releases** : Penser à mettre à jour `.claude-plugin/marketplace.json` en même temps que `package.json` lors des bumps de version, sinon le marketplace affichera une version obsolète.