### PR TITLE
fix(plugin): remove invalid category field from plugin.json

### DIFF
--- a/claude-code-config/.claude-plugin/plugin.json
+++ b/claude-code-config/.claude-plugin/plugin.json
@@ -18,6 +18,5 @@
     "hooks",
     "workflows",
     "statusline"
-  ],
-  "category": "essentials"
+  ]
 }


### PR DESCRIPTION
 The [plugin.json](https://code.claude.com/docs/en/plugins-reference) file contained fields that are only valid in marketplace.json    

<img width="1000" height="423" alt="image" src="https://github.com/user-attachments/assets/be963eaa-4081-4d89-8a3e-279a1ff5575a" />

Summary                                                                                                                                                                                                                                   
  - Remove invalid category field from plugin.json manifest  
  
                                                                                                                                                                                      