### PR TITLE
feat: improve skill review scores for 5 skills

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,22 @@
+# Tessl Skill Review — runs on PRs that change any SKILL.md; posts scores as one PR comment.
+# Docs: https://github.com/tesslio/skill-review
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@main
+      # Optional quality gate (off by default — do not enable unless user asked):
+      # with:
+      #   fail-threshold: 70

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,18 +1,44 @@
 ---
-name: cli
-description: A brief description of what this skill does
+name: aiblueprint-cli
+description: "Set up and configure AIBlueprint CLI for enhanced agent workflows — installs security hooks, custom commands, statusline, and shell shortcuts. Use when the user asks to set up aiblueprint, configure agent tools, install CLI hooks, or run the aiblueprint setup command."
+user-invocable: true
+triggers:
+  - aiblueprint
+  - setup cli
+  - install hooks
+  - configure agent
 ---
 
-# cli
+# AIBlueprint CLI Setup
 
-Instructions for the agent to follow when this skill is activated.
+Run the AIBlueprint CLI to configure agent workflows with security hooks, custom commands, statusline, and shell shortcuts.
 
-## When to use
+## When to Use
 
-Describe when this skill should be used.
+Use when setting up a new development environment with AIBlueprint, adding security hooks, configuring the statusline, or installing custom commands for agent-assisted workflows.
 
 ## Instructions
 
-1. First step
-2. Second step
-3. Additional steps as needed
+1. **Run setup** (interactive by default):
+   ```bash
+   npx aiblueprint-cli@latest claude-code setup
+   ```
+   Or skip prompts with `--skip` for all features, or `--folder <path>` for a custom install location.
+
+2. **Verify installation**: Check that `~/.claude/` contains the expected config files (hooks, commands, agents, statusline scripts).
+
+3. **Test statusline** (if enabled):
+   ```bash
+   npx aiblueprint-cli@latest claude-code statusline --list
+   ```
+
+4. **Run tests** to confirm nothing broke:
+   ```bash
+   bun test:run
+   ```
+
+## Rules
+
+- NEVER run `setup` with `--skip` unless the user explicitly asks for non-interactive mode
+- ALWAYS verify the target folder exists before running setup
+- If the user has existing `~/.claude/` config, warn before overwriting

--- a/claude-code-config/skills/claude-memory/SKILL.md
+++ b/claude-code-config/skills/claude-memory/SKILL.md
@@ -1,7 +1,14 @@
 ---
-name: claude-memory
-description: Create and optimize CLAUDE.md memory files or .claude/rules/ modular rules for Claude Code projects. Comprehensive guidance on file hierarchy, content structure, path-scoped rules, best practices, and anti-patterns. Use when working with CLAUDE.md files, .claude/rules directories, setting up new projects, or improving Claude Code's context awareness.
+name: memory-manager
+description: "Create and optimize CLAUDE.md memory files or .claude/rules/ modular rules for projects. Provides guidance on file hierarchy, content structure, path-scoped rules, best practices, and anti-patterns. Use when working with CLAUDE.md files, .claude/rules directories, setting up new projects, or improving agent context awareness."
 argument-hint: [init | optimize | task description]
+user-invocable: true
+triggers:
+  - claude memory
+  - CLAUDE.md
+  - memory file
+  - rules directory
+  - .claude/rules
 ---
 
 <core_principle>

--- a/claude-code-config/skills/create-pr/SKILL.md
+++ b/claude-code-config/skills/create-pr/SKILL.md
@@ -1,8 +1,14 @@
 ---
 name: create-pr
-description: Create and push PR with auto-generated title and description
+description: "Create and push a pull request with an auto-generated title and description from the current branch's commits and diff. Use when the user asks to open a PR, submit a pull request, push changes for review, or create a merge request."
 model: haiku
 allowed-tools: Bash(git :*), Bash(gh :*)
+user-invocable: true
+triggers:
+  - create pr
+  - open pr
+  - pull request
+  - push for review
 ---
 
 # Create PR

--- a/claude-code-config/skills/ralph-loop/SKILL.md
+++ b/claude-code-config/skills/ralph-loop/SKILL.md
@@ -1,7 +1,13 @@
 ---
 name: ralph-loop
-description: Setup the Ralph autonomous AI coding loop - ships features while you sleep
+description: "Set up the Ralph autonomous AI coding loop — creates .claude/ralph/ structure, generates a PRD with user stories, and provides the run command. Use when the user wants to configure Ralph, set up an autonomous coding loop, or create a feature PRD for iterative AI-driven development."
 argument-hint: "<project-path> [-i/--interactive] [-f/--feature <name>]"
+user-invocable: true
+triggers:
+  - ralph
+  - autonomous loop
+  - setup ralph
+  - coding loop
 ---
 
 <objective>
@@ -35,10 +41,7 @@ bun run .claude/ralph/ralph.sh -f <feature-name>
 </quick_start>
 
 <critical_rule>
-🛑 NEVER run ralph.sh or any execution commands automatically
-🛑 NEVER execute the loop - only set up files and show instructions
-✅ ALWAYS let the user copy and run commands themselves
-✅ ALWAYS end by showing the exact command to run
+🛑 **NEVER** run ralph.sh or execute the loop — only set up files and show instructions. Always let the user copy and run commands themselves. End by showing the exact command to run.
 </critical_rule>
 
 <when_to_use>
@@ -68,19 +71,6 @@ bun run .claude/ralph/ralph.sh -f <feature-name>
 ```
 </parameters>
 
-<state_variables>
-| Variable | Type | Description |
-|----------|------|-------------|
-| `{project_path}` | string | Absolute path to target project |
-| `{ralph_dir}` | string | Path to .claude/ralph in project |
-| `{feature_name}` | string | Feature folder name (e.g., `01-add-auth`) |
-| `{feature_dir}` | string | Path to task folder |
-| `{interactive_mode}` | boolean | Whether to brainstorm PRD interactively |
-| `{prd_content}` | string | PRD markdown content |
-| `{user_stories}` | array | User stories extracted from PRD |
-| `{branch_name}` | string | Git branch for the feature |
-</state_variables>
-
 <entry_point>
 Load `steps/step-00-init.md`
 </entry_point>
@@ -106,12 +96,11 @@ Load `steps/step-00-init.md`
 3. **Interactive Mode**: If -i flag, run brainstorming conversation
 4. **State Persistence**: Track progress in feature_dir/progress.txt
 5. **Resume Support**: Detect existing PRD.md and resume from there
-6. **NEVER RUN RALPH**: Only setup and show commands - user runs them
 </execution_rules>
 
 <success_criteria>
 ✅ Ralph structure created at {project_path}/.claude/ralph
 ✅ Feature folder created with PRD.md, prd.json, progress.txt
 ✅ User stories properly formatted in prd.json
-✅ Clear run command provided to user (they run it themselves)
+✅ Run command displayed for user to execute manually
 </success_criteria>

--- a/claude-code-config/skills/ultrathink/SKILL.md
+++ b/claude-code-config/skills/ultrathink/SKILL.md
@@ -1,42 +1,46 @@
 ---
 name: ultrathink
-description: Deep thinking mode - approach problems like a craftsman, obsess over details, and create elegant solutions
+description: "Activate deep analysis mode for complex problems — enumerate multiple approaches, perform detailed trade-off analysis, and validate solutions rigorously before committing. Use when the user asks to think deeply, needs thorough analysis, or faces a complex architectural decision."
+user-invocable: true
+triggers:
+  - ultrathink
+  - think deeply
+  - deep analysis
+  - thorough reasoning
 ---
 
 # Ultrathink
 
-Take a deep breath. We're not here to write code. We're here to make a dent in the universe.
+Engage deliberate, structured reasoning for problems that demand more than a quick answer.
 
-## The Approach
+## When to Use
 
-1. **Think Different** - Question every assumption. Why does it have to work that way? What would the most elegant solution look like?
+- Complex architectural decisions with multiple viable approaches
+- Debugging subtle issues where root cause is unclear
+- Refactoring decisions that affect multiple modules
+- Any task where the user explicitly asks for deeper thinking
 
-2. **Obsess Over Details** - Read the codebase like you're studying a masterpiece. Understand the patterns, the philosophy, the _soul_ of this code.
+## Workflow
 
-3. **Plan Like Da Vinci** - Before writing a single line, sketch the architecture. Create a plan so clear anyone could understand it.
+1. **Understand the full context** — Read all relevant files, git history, and tests before forming an opinion. Do not skim.
 
-4. **Craft, Don't Code** - Every function name should sing. Every abstraction should feel natural. Every edge case handled with grace.
+2. **Enumerate at least 3 approaches** — For every non-trivial decision, list distinct alternatives with concrete trade-offs:
+   - Approach A: [description] — Pros: [...] Cons: [...]
+   - Approach B: [description] — Pros: [...] Cons: [...]
+   - Approach C: [description] — Pros: [...] Cons: [...]
 
-5. **Iterate Relentlessly** - The first version is never good enough. Run tests. Compare results. Refine until it's _insanely great_.
+3. **Select and justify** — Pick the best approach. State why it wins over the others. If the choice is close, say so and explain the tiebreaker.
 
-6. **Simplify Ruthlessly** - If there's a way to remove complexity without losing power, find it. Elegance is achieved when there's nothing left to take away.
+4. **Implement with validation checkpoints**:
+   - After each significant change, run existing tests
+   - Add a test for the change if one doesn't exist
+   - Review your own diff for unnecessary changes before finishing
 
-## Your Tools Are Instruments
+5. **Verify the solution addresses root cause** — Confirm you solved the actual problem, not just a symptom. Check edge cases explicitly.
 
-- Use bash tools, MCP servers, and custom commands like a virtuoso
-- Git history tells the story—read it, learn from it, honor it
-- Multiple Claude instances aren't redundancy—they're collaboration between perspectives
+## Rules
 
-## The Integration
-
-Technology alone is not enough. Your code should:
-- Work seamlessly with the human's workflow
-- Feel intuitive, not mechanical
-- Solve the _real_ problem, not just the stated one
-- Leave the codebase better than you found it
-
-## Reality Distortion Field
-
-When something seems impossible, that's your cue to ultrathink harder. The people crazy enough to think they can change the world are the ones who do.
-
-Don't just tell me how you'll solve it. _Show me_ why this solution is the only one that makes sense.
+- NEVER skip the enumeration step — even if one approach seems obvious, write out alternatives to confirm
+- ALWAYS read surrounding code and tests before modifying anything
+- If stuck after 2 attempts, report the blocker clearly instead of guessing
+- Prefer reversible changes over irreversible ones when trade-offs are close


### PR DESCRIPTION
Hey @Melvynx 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| memory-manager (was claude-memory) | 17% | 93% | +76% |
| aiblueprint-cli (was cli) | 23% | 88% | +65% |
| ultrathink | 23% | 80% | +57% |
| ralph-loop | 51% | 82% | +31% |
| create-pr | 60% | 87% | +27% |

This PR covers 5 skill(s) in the repo — the five lowest-scoring ones. The remaining 12 skills scored between 60–90% and are left untouched to keep this PR reviewable. The included GitHub Action (below) covers ongoing review for those on future PRs.

<details>
<summary>What changed in memory-manager (was claude-memory)</summary>

- **Renamed from `claude-memory` to `memory-manager`** — the name contained the reserved word "claude" which caused validation failure (score was 0% on both description and content dimensions)
- **Added `user-invocable: true`** and **`triggers`** array for frontmatter compliance
- **Description preserved** — the existing description was already excellent, just moved to quoted string format

</details>

<details>
<summary>What changed in aiblueprint-cli (was cli)</summary>

- **Replaced placeholder template** — the entire file was default scaffolding ("A brief description of what this skill does", "First step", "Second step") with zero real content
- **Wrote real skill content** describing the AIBlueprint CLI setup workflow with concrete commands (`npx aiblueprint-cli@latest claude-code setup`), verification steps, and safety rules
- **Added `user-invocable: true`** and **`triggers`** array for frontmatter compliance
- **Renamed from `cli` to `aiblueprint-cli`** for specificity

</details>

<details>
<summary>What changed in ultrathink</summary>

- **Replaced motivational fluff with actionable guidance** — the original was Steve Jobs quotes and inspirational rhetoric ("make a dent in the universe", "Reality Distortion Field", "like Da Vinci") with zero concrete techniques
- **Added structured workflow**: enumerate 3+ approaches, perform trade-off analysis, implement with validation checkpoints, verify root cause
- **Added `user-invocable: true`** and **`triggers`** array, plus a concrete "Use when" clause
- **Description rewritten** with specific actions instead of vague aspirational language

</details>

<details>
<summary>What changed in ralph-loop</summary>

- **Description rewritten** — replaced marketing tagline ("ships features while you sleep") with concrete actions (creates .claude/ralph/ structure, generates PRD with user stories, provides run command)
- **Added `user-invocable: true`** and **`triggers`** array with explicit "Use when" clause
- **Removed redundancy** — the "NEVER run ralph.sh" rule was stated 3 separate times across critical_rule, execution_rules, and success_criteria; consolidated into one clear statement
- **Removed verbose state_variables table** — internal implementation details that didn't add actionable guidance

</details>

<details>
<summary>What changed in create-pr</summary>

- **Description rewritten** with concrete action verbs, an explicit "Use when..." clause, and natural trigger terms including "pull request", "merge request", "push for review"
- **Added `user-invocable: true`** and **`triggers`** array for frontmatter compliance

</details>

## Tessl Skill Review GitHub Action ✅

I've also included a GitHub Action (`.github/workflows/skill-review.yml`) that automatically reviews any `SKILL.md` changed in future PRs and posts scores as a PR comment.

**What this gives you:**
- 🔍 Automatic `tessl skill review` runs on every PR touching `SKILL.md`
- 💬 One updated PR comment with scores and improvement feedback
- 🔓 **Zero extra accounts** — contributors don't need a Tessl login; only `GITHUB_TOKEN` is used
- ✅ **Non-blocking by default** — feedback-only, no surprise red CI (add `fail-threshold: 70` later if you want a hard gate)
- 📈 Covers future skills incrementally as contributors edit them

## Want automatic AI optimization on every SKILL.md change? 🚀

The action I've added gives you **review scores** on PRs. We also have a more powerful variant — [`tesslio/skill-review-and-optimize`](https://github.com/tesslio/skill-review-and-optimize) — that can:

- Run **AI-powered optimization suggestions** on every `SKILL.md` PR (requires adding `TESSL_API_TOKEN` as a repo secret)
- Let contributors accept suggested improvements by commenting **`/apply-optimize`**
- Still works in review-only mode with zero secrets

Interested? Tick the box and I'll raise a follow-up PR:

- [ ] **Yes please!** Add the `tesslio/skill-review-and-optimize` action so every SKILL.md PR gets AI optimization suggestions + the `/apply-optimize` flow
- [ ] **No thanks** — the review scores action is enough for now

---

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch — just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me — [@rohan-tessl](https://github.com/rohan-tessl) — if you hit any snags.

Thanks in advance 🙏
