### PR TITLE
fix(pro-installer): handle flat .md files when applying path placeholders

### DIFF
--- a/src/lib/agents-installer.ts
+++ b/src/lib/agents-installer.ts
@@ -8,7 +8,7 @@ import {
   replacePathPlaceholdersInDir,
 } from "./platform.js";
 
-async function applyPathPlaceholders(target: string, claudeDir: string): Promise<void> {
+export async function applyPathPlaceholders(target: string, claudeDir: string): Promise<void> {
   const stat = await fs.stat(target).catch(() => null);
   if (!stat) return;
   if (stat.isDirectory()) {

--- a/src/lib/pro-installer.ts
+++ b/src/lib/pro-installer.ts
@@ -8,6 +8,7 @@ import {
   AGENT_CATEGORIES,
   syncCategorySymlinks,
   isAgentCategory,
+  applyPathPlaceholders,
 } from "./agents-installer.js";
 import { resolveFolders } from "./folder-paths.js";
 
@@ -181,7 +182,7 @@ async function copyConfigFromCache(
   await walk(cacheConfigDir);
 }
 
-async function copyAgentCategory(
+export async function copyAgentCategory(
   sourceCategoryDir: string,
   category: "skills" | "agents",
   agentsDir: string,
@@ -205,7 +206,7 @@ async function copyAgentCategory(
     }
 
     await fs.copy(src, dst, { overwrite: true });
-    await replacePathPlaceholdersInDir(dst, claudeDir);
+    await applyPathPlaceholders(dst, claudeDir);
     onProgress?.(`${category}/${entry.name}`, entry.isDirectory() ? "directory" : "file");
   }
 }

--- a/tests/pro-installer.test.ts
+++ b/tests/pro-installer.test.ts
@@ -1,0 +1,122 @@
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { copyAgentCategory } from "../src/lib/pro-installer";
+
+const TMP_ROOT = path.join(os.tmpdir(), "aiblueprint-pro-installer-test");
+
+interface Fixture {
+  root: string;
+  sourceCategoryDir: string;
+  agentsDir: string;
+  claudeDir: string;
+}
+
+async function makeFixture(suffix: string): Promise<Fixture> {
+  const root = path.join(TMP_ROOT, `${Date.now()}-${suffix}`);
+  const sourceCategoryDir = path.join(root, "source", "agents");
+  const agentsDir = path.join(root, "agents");
+  const claudeDir = path.join(root, "claude");
+  await fs.ensureDir(sourceCategoryDir);
+  await fs.ensureDir(agentsDir);
+  await fs.ensureDir(claudeDir);
+  return { root, sourceCategoryDir, agentsDir, claudeDir };
+}
+
+describe("copyAgentCategory", () => {
+  let fixture: Fixture;
+
+  beforeEach(async () => {
+    fixture = await makeFixture("copy");
+  });
+
+  afterEach(async () => {
+    await fs.remove(fixture.root).catch(() => {});
+  });
+
+  it("copies a flat .md agent file without trying to scandir it (regression: ENOTDIR)", async () => {
+    // Reproduces the exact scenario that crashed v1.4.55:
+    // source agents-config/agents/code-architect.md is a FILE (not a dir),
+    // so the post-copy placeholder pass must not call readdir on it.
+    const sourceFile = path.join(fixture.sourceCategoryDir, "code-architect.md");
+    await fs.writeFile(
+      sourceFile,
+      "agent body referencing {CLAUDE_PATH}/song/finish.mp3",
+      "utf-8",
+    );
+
+    await expect(
+      copyAgentCategory(
+        fixture.sourceCategoryDir,
+        "agents",
+        fixture.agentsDir,
+        fixture.claudeDir,
+      ),
+    ).resolves.not.toThrow();
+
+    const dst = path.join(fixture.agentsDir, "agents", "code-architect.md");
+    expect(await fs.pathExists(dst)).toBe(true);
+
+    const content = await fs.readFile(dst, "utf-8");
+    expect(content).toBe(
+      `agent body referencing ${fixture.claudeDir}/song/finish.mp3`,
+    );
+  });
+
+  it("still handles directory-shaped entries (legacy skill layout)", async () => {
+    const skillDir = path.join(fixture.sourceCategoryDir, "alpha");
+    await fs.ensureDir(skillDir);
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      "skill body with {CLAUDE_PATH}",
+      "utf-8",
+    );
+
+    await copyAgentCategory(
+      fixture.sourceCategoryDir,
+      "agents",
+      fixture.agentsDir,
+      fixture.claudeDir,
+    );
+
+    const dst = path.join(fixture.agentsDir, "agents", "alpha", "SKILL.md");
+    expect(await fs.pathExists(dst)).toBe(true);
+    const content = await fs.readFile(dst, "utf-8");
+    expect(content).toBe(`skill body with ${fixture.claudeDir}`);
+  });
+
+  it("skips entries when claudeDir already has a real (non-symlink) entry at that path", async () => {
+    await fs.writeFile(
+      path.join(fixture.sourceCategoryDir, "code-architect.md"),
+      "from source",
+      "utf-8",
+    );
+    const claudeCategoryDir = path.join(fixture.claudeDir, "agents");
+    await fs.ensureDir(claudeCategoryDir);
+    await fs.writeFile(
+      path.join(claudeCategoryDir, "code-architect.md"),
+      "user-edited",
+      "utf-8",
+    );
+
+    const progress: { file: string; type: "file" | "directory" }[] = [];
+    await copyAgentCategory(
+      fixture.sourceCategoryDir,
+      "agents",
+      fixture.agentsDir,
+      fixture.claudeDir,
+      (file, type) => progress.push({ file, type }),
+    );
+
+    // The .agents target should NOT have been created.
+    expect(
+      await fs.pathExists(
+        path.join(fixture.agentsDir, "agents", "code-architect.md"),
+      ),
+    ).toBe(false);
+
+    expect(progress).toHaveLength(1);
+    expect(progress[0].file).toContain("skipped");
+  });
+});


### PR DESCRIPTION
## Summary

`copyAgentCategory` calls `replacePathPlaceholdersInDir` on the copied destination, but the destination is a **file** when the source entry is a flat `.md` (the current layout of [`aiblueprint-cli-premium/agents-config/agents/`](https://github.com/Melvynx/aiblueprint-cli-premium/tree/main/agents-config/agents)). `replacePathPlaceholdersInDir` runs `fs.readdir` on its argument, which throws `ENOTDIR` and breaks `agents pro setup`:

```
Failed to install premium configs: ENOTDIR: not a directory,
scandir '~/.agents/agents/code-architect.md'
```

This was reproducible on Windows running `npx aiblueprint-cli@latest agents pro setup` against the current premium repo.

## Fix

Switch to `applyPathPlaceholders` — the existing helper in `agents-installer.ts` that branches on file vs directory (already used by `installCategoryToAgents`). Export it so `pro-installer.ts` can reuse it.

Diff is intentionally minimal:
- `src/lib/agents-installer.ts`: `export` `applyPathPlaceholders` (+1/-1)
- `src/lib/pro-installer.ts`: import + use the helper, export `copyAgentCategory` for the test (+3/-2)
- `tests/pro-installer.test.ts`: new regression test file (+122)

## Test plan

- [x] Added `tests/pro-installer.test.ts` with 3 cases:
  - **Regression**: flat `.md` source entry — fails with `ENOTDIR` before the fix, passes after.
  - **Legacy layout**: directory-shaped entry still works (no regression on `{CLAUDE_PATH}` substitution inside).
  - **Skip path**: existing real (non-symlink) entry in `claudeDir` is correctly skipped.
- [x] Verified the regression test fails on `main` with **exactly** the original error (`ENOTDIR: scandir '...\agents\agents\code-architect.md'`) by reverting only the fix line.
- [x] `bun test:run` — `103 passed / 9 failed` (the 9 failures are pre-existing Windows path/symlink-permission issues unrelated to this change; same counts before and after).
- [x] `bun run build` — OK.