### PR TITLE
fix(platform): preserve backslashes in shell scripts during sync

### DIFF
--- a/src/lib/agents-installer.ts
+++ b/src/lib/agents-installer.ts
@@ -8,7 +8,7 @@ import {
   replacePathPlaceholdersInDir,
 } from "./platform.js";
 
-async function applyPathPlaceholders(target: string, claudeDir: string): Promise<void> {
+export async function applyPathPlaceholders(target: string, claudeDir: string): Promise<void> {
   const stat = await fs.stat(target).catch(() => null);
   if (!stat) return;
   if (stat.isDirectory()) {

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -146,19 +146,18 @@ const KNOWN_CLAUDE_PATHS = [
 ];
 
 export function transformHookCommand(command: string, claudeDir: string): string {
+  const normalizedClaudeDir = claudeDir.replace(/\\/g, "/");
   let transformed = command;
 
-  transformed = replaceClaudePathPlaceholder(transformed, claudeDir);
+  transformed = replaceClaudePathPlaceholder(transformed, normalizedClaudeDir);
 
   for (const pattern of KNOWN_CLAUDE_PATHS) {
-    transformed = transformed.replace(pattern, `${claudeDir}/`);
+    transformed = transformed.replace(pattern, `${normalizedClaudeDir}/`);
   }
-
-  transformed = transformed.replace(/\\/g, "/");
 
   const isAudioCommand = /^(afplay|paplay|aplay|mpv|ffplay|powershell)\s/.test(transformed);
   if (isAudioCommand) {
-    const newCommand = transformAudioCommand(transformed, claudeDir);
+    const newCommand = transformAudioCommand(transformed, normalizedClaudeDir);
     if (newCommand) {
       return newCommand;
     }
@@ -236,15 +235,14 @@ export async function replacePathPlaceholdersInDir(dir: string, claudeDir: strin
 }
 
 export function transformFileContent(content: string, claudeDir: string): string {
+  const normalizedClaudeDir = claudeDir.replace(/\\/g, "/");
   let transformed = content;
 
-  transformed = replaceClaudePathPlaceholder(transformed, claudeDir);
+  transformed = replaceClaudePathPlaceholder(transformed, normalizedClaudeDir);
 
   for (const pattern of KNOWN_CLAUDE_PATHS) {
-    transformed = transformed.replace(new RegExp(pattern.source, "g"), `${claudeDir}/`);
+    transformed = transformed.replace(new RegExp(pattern.source, "g"), `${normalizedClaudeDir}/`);
   }
-
-  transformed = transformed.replace(/\\/g, "/");
 
   const audioPatterns = [
     /afplay\s+-v\s+[\d.]+\s+'[^']+'/g,
@@ -257,7 +255,7 @@ export function transformFileContent(content: string, claudeDir: string): string
 
   for (const pattern of audioPatterns) {
     transformed = transformed.replace(pattern, (match) => {
-      const newCommand = transformAudioCommand(match, claudeDir);
+      const newCommand = transformAudioCommand(match, normalizedClaudeDir);
       return newCommand || match;
     });
   }

--- a/src/lib/pro-installer.ts
+++ b/src/lib/pro-installer.ts
@@ -8,6 +8,7 @@ import {
   AGENT_CATEGORIES,
   syncCategorySymlinks,
   isAgentCategory,
+  applyPathPlaceholders,
 } from "./agents-installer.js";
 import { resolveFolders } from "./folder-paths.js";
 
@@ -181,7 +182,7 @@ async function copyConfigFromCache(
   await walk(cacheConfigDir);
 }
 
-async function copyAgentCategory(
+export async function copyAgentCategory(
   sourceCategoryDir: string,
   category: "skills" | "agents",
   agentsDir: string,
@@ -205,7 +206,7 @@ async function copyAgentCategory(
     }
 
     await fs.copy(src, dst, { overwrite: true });
-    await replacePathPlaceholdersInDir(dst, claudeDir);
+    await applyPathPlaceholders(dst, claudeDir);
     onProgress?.(`${category}/${entry.name}`, entry.isDirectory() ? "directory" : "file");
   }
 }

--- a/tests/pro-installer.test.ts
+++ b/tests/pro-installer.test.ts
@@ -1,0 +1,122 @@
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { copyAgentCategory } from "../src/lib/pro-installer";
+
+const TMP_ROOT = path.join(os.tmpdir(), "aiblueprint-pro-installer-test");
+
+interface Fixture {
+  root: string;
+  sourceCategoryDir: string;
+  agentsDir: string;
+  claudeDir: string;
+}
+
+async function makeFixture(suffix: string): Promise<Fixture> {
+  const root = path.join(TMP_ROOT, `${Date.now()}-${suffix}`);
+  const sourceCategoryDir = path.join(root, "source", "agents");
+  const agentsDir = path.join(root, "agents");
+  const claudeDir = path.join(root, "claude");
+  await fs.ensureDir(sourceCategoryDir);
+  await fs.ensureDir(agentsDir);
+  await fs.ensureDir(claudeDir);
+  return { root, sourceCategoryDir, agentsDir, claudeDir };
+}
+
+describe("copyAgentCategory", () => {
+  let fixture: Fixture;
+
+  beforeEach(async () => {
+    fixture = await makeFixture("copy");
+  });
+
+  afterEach(async () => {
+    await fs.remove(fixture.root).catch(() => {});
+  });
+
+  it("copies a flat .md agent file without trying to scandir it (regression: ENOTDIR)", async () => {
+    // Reproduces the exact scenario that crashed v1.4.55:
+    // source agents-config/agents/code-architect.md is a FILE (not a dir),
+    // so the post-copy placeholder pass must not call readdir on it.
+    const sourceFile = path.join(fixture.sourceCategoryDir, "code-architect.md");
+    await fs.writeFile(
+      sourceFile,
+      "agent body referencing {CLAUDE_PATH}/song/finish.mp3",
+      "utf-8",
+    );
+
+    await expect(
+      copyAgentCategory(
+        fixture.sourceCategoryDir,
+        "agents",
+        fixture.agentsDir,
+        fixture.claudeDir,
+      ),
+    ).resolves.not.toThrow();
+
+    const dst = path.join(fixture.agentsDir, "agents", "code-architect.md");
+    expect(await fs.pathExists(dst)).toBe(true);
+
+    const content = await fs.readFile(dst, "utf-8");
+    expect(content).toBe(
+      `agent body referencing ${fixture.claudeDir}/song/finish.mp3`,
+    );
+  });
+
+  it("still handles directory-shaped entries (legacy skill layout)", async () => {
+    const skillDir = path.join(fixture.sourceCategoryDir, "alpha");
+    await fs.ensureDir(skillDir);
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      "skill body with {CLAUDE_PATH}",
+      "utf-8",
+    );
+
+    await copyAgentCategory(
+      fixture.sourceCategoryDir,
+      "agents",
+      fixture.agentsDir,
+      fixture.claudeDir,
+    );
+
+    const dst = path.join(fixture.agentsDir, "agents", "alpha", "SKILL.md");
+    expect(await fs.pathExists(dst)).toBe(true);
+    const content = await fs.readFile(dst, "utf-8");
+    expect(content).toBe(`skill body with ${fixture.claudeDir}`);
+  });
+
+  it("skips entries when claudeDir already has a real (non-symlink) entry at that path", async () => {
+    await fs.writeFile(
+      path.join(fixture.sourceCategoryDir, "code-architect.md"),
+      "from source",
+      "utf-8",
+    );
+    const claudeCategoryDir = path.join(fixture.claudeDir, "agents");
+    await fs.ensureDir(claudeCategoryDir);
+    await fs.writeFile(
+      path.join(claudeCategoryDir, "code-architect.md"),
+      "user-edited",
+      "utf-8",
+    );
+
+    const progress: { file: string; type: "file" | "directory" }[] = [];
+    await copyAgentCategory(
+      fixture.sourceCategoryDir,
+      "agents",
+      fixture.agentsDir,
+      fixture.claudeDir,
+      (file, type) => progress.push({ file, type }),
+    );
+
+    // The .agents target should NOT have been created.
+    expect(
+      await fs.pathExists(
+        path.join(fixture.agentsDir, "agents", "code-architect.md"),
+      ),
+    ).toBe(false);
+
+    expect(progress).toHaveLength(1);
+    expect(progress[0].file).toContain("skipped");
+  });
+});


### PR DESCRIPTION
## Summary

- Removes the blanket `transformed = transformed.replace(/\/g, "/")` from both `transformHookCommand` and `transformFileContent`
- Instead, normalizes only the `claudeDir` parameter at the top of each function via `const normalizedClaudeDir = claudeDir.replace(/\/g, "/")` and uses that throughout
- All uses of `claudeDir` inside the two functions (including calls to `replaceClaudePathPlaceholder` and `transformAudioCommand`) are updated to use `normalizedClaudeDir`

## The Bug

When running `bunx aiblueprint-cli@latest claude-code pro sync` on Windows, the blanket backslash→slash replace was applied to **every character** in every text file being processed — not just to the `claudeDir` path value being injected. This destroyed bash `\` line-continuation characters in `.sh` files (e.g. the apex skill's `setup-templates.sh`), turning them into `/` and breaking the entire script.

Reported by ishake.fouhal@gmail.com on Windows 11.

## Test plan

- [ ] Verify `bun run build` succeeds with no TypeScript errors
- [ ] On Windows, run `pro sync` and confirm `.sh` files with `\` line-continuations are not corrupted
- [ ] Confirm Windows-style paths in `claudeDir` (backslashes) are still normalized to forward slashes when injected as `{CLAUDE_PATH}` substitutions

🤖 Generated with [Claude Code](https://claude.com/claude-code)